### PR TITLE
feat: load multiple cached datasets

### DIFF
--- a/scripts/train_bm4dnet.py
+++ b/scripts/train_bm4dnet.py
@@ -14,64 +14,108 @@ os.environ["GRPC_TRACE"] = ""
 _REQUIRED_CACHE_FILES = ("raw.npy", "teacher.npy", "fg.npy", "transform.json")
 
 
-def _load_cached_transform(train_cache_dir, val_cache_dir):
-    """Validates both patch caches and returns their shared transform."""
-    cache_dirs = {
-        "train_cache_dir": train_cache_dir,
-        "val_cache_dir": val_cache_dir,
-    }
-    transform_cfgs = {}
-    for name, cache_dir in cache_dirs.items():
-        if not cache_dir:
-            raise ValueError(f"{name} is required for training")
-        if not os.path.isdir(cache_dir):
-            raise FileNotFoundError(
-                f"{name} does not exist or is not a directory: {cache_dir}"
-            )
-        missing = [
-            filename
-            for filename in _REQUIRED_CACHE_FILES
-            if not os.path.isfile(os.path.join(cache_dir, filename))
-        ]
-        if missing:
-            raise FileNotFoundError(
-                f"{name} is missing required cache files: "
-                + ", ".join(missing)
-            )
-        transform_cfgs[name] = util.read_json(
-            os.path.join(cache_dir, "transform.json")
-        )
+def _normalize_cache_dirs(cache_dir, name):
+    """Returns one or more cache paths as a nonempty list of strings."""
+    if cache_dir is None:
+        raise ValueError(f"{name} is required for training")
+    if isinstance(cache_dir, (str, os.PathLike)):
+        cache_dirs = [cache_dir]
+    else:
+        try:
+            cache_dirs = list(cache_dir)
+        except TypeError as error:
+            raise TypeError(
+                f"{name} must be a path or an iterable of paths"
+            ) from error
 
-    if transform_cfgs["train_cache_dir"] != transform_cfgs["val_cache_dir"]:
-        raise ValueError(
-            "train and validation patch caches use different transforms"
-        )
-    return build_transform(transform_cfgs["train_cache_dir"])
+    if not cache_dirs:
+        raise ValueError(f"{name} is required for training")
+
+    normalized = []
+    for index, path in enumerate(cache_dirs):
+        if not isinstance(path, (str, os.PathLike)):
+            raise TypeError(f"{name}[{index}] is not a path: {path!r}")
+        normalized.append(os.fspath(path))
+    return normalized
+
+
+def _load_cached_transform(train_cache_dir, val_cache_dir):
+    """Validates all patch caches and returns their shared transform."""
+    cache_groups = {
+        "train_cache_dir": _normalize_cache_dirs(
+            train_cache_dir, "train_cache_dir"
+        ),
+        "val_cache_dir": _normalize_cache_dirs(val_cache_dir, "val_cache_dir"),
+    }
+    transform_cfg = None
+    for name, cache_dirs in cache_groups.items():
+        for index, cache_dir in enumerate(cache_dirs):
+            label = name if len(cache_dirs) == 1 else f"{name}[{index}]"
+            if not os.path.isdir(cache_dir):
+                raise FileNotFoundError(
+                    f"{label} does not exist or is not a directory: "
+                    f"{cache_dir}"
+                )
+            missing = [
+                filename
+                for filename in _REQUIRED_CACHE_FILES
+                if not os.path.isfile(os.path.join(cache_dir, filename))
+            ]
+            if missing:
+                raise FileNotFoundError(
+                    f"{label} is missing required cache files: "
+                    + ", ".join(missing)
+                )
+            current_cfg = util.read_json(
+                os.path.join(cache_dir, "transform.json")
+            )
+            if transform_cfg is None:
+                transform_cfg = current_cfg
+            elif current_cfg != transform_cfg:
+                raise ValueError(
+                    "train and validation patch caches use different "
+                    f"transforms: {label}"
+                )
+    return build_transform(transform_cfg)
 
 
 def train(train_cache_dir, val_cache_dir):
     """Trains and validates exclusively from precomputed patch caches."""
     # Per-brain offsets and the BM4D teacher are already baked into the cached
     # counts. Both caches must use the identical count-space transform.
-    transform = _load_cached_transform(train_cache_dir, val_cache_dir)
+    train_cache_dirs = _normalize_cache_dirs(
+        train_cache_dir, "train_cache_dir"
+    )
+    val_cache_dirs = _normalize_cache_dirs(val_cache_dir, "val_cache_dir")
+    transform = _load_cached_transform(train_cache_dirs, val_cache_dirs)
+    train_cache_arg = (
+        train_cache_dirs[0] if len(train_cache_dirs) == 1 else train_cache_dirs
+    )
+    val_cache_arg = (
+        val_cache_dirs[0] if len(val_cache_dirs) == 1 else val_cache_dirs
+    )
     train_dataset = data_handling.CachedPatchDataset(
-        train_cache_dir,
+        train_cache_arg,
         transform=transform,
         preserve_foreground=preserve_foreground,
     )
     val_dataset = data_handling.CachedValidateDataset(
-        val_cache_dir,
+        val_cache_arg,
         transform=transform,
         preserve_foreground=preserve_foreground,
     )
     print("Transform:", transform.cfg)
     print(
-        "Training from cache:", train_cache_dir,
-        "| pool size:", len(train_dataset.raw),
+        "Training from cache:",
+        train_cache_arg,
+        "| pool size:",
+        len(train_dataset),
     )
     print(
-        "Validating from cache:", val_cache_dir,
-        "| examples:", len(val_dataset),
+        "Validating from cache:",
+        val_cache_arg,
+        "| examples:",
+        len(val_dataset),
     )
 
     # Cached patches are cheap to load, so read them in-thread.
@@ -94,8 +138,8 @@ def train(train_cache_dir, val_cache_dir):
     # session is reproducible (the Trainer merges in its own hyperparameters).
     trainer.save_config(
         {
-            "train_cache_dir": train_cache_dir,
-            "val_cache_dir": val_cache_dir,
+            "train_cache_dir": train_cache_arg,
+            "val_cache_dir": val_cache_arg,
             "resume_path": resume_path,
             "transform_cfg": transform.cfg,
             "preserve_foreground": preserve_foreground,

--- a/src/aind_exaspim_image_compression/machine_learning/data_handling.py
+++ b/src/aind_exaspim_image_compression/machine_learning/data_handling.py
@@ -10,6 +10,7 @@ Routines for loading data during training and inference.
 
 from aind_exaspim_dataset_utils.s3_util import get_img_prefix
 from bm4d import bm4d
+from collections.abc import Iterable
 from concurrent.futures import (
     as_completed, ProcessPoolExecutor, ThreadPoolExecutor,
 )
@@ -796,8 +797,12 @@ class TrainDataset(Dataset):
 class ValidateDataset(Dataset):
 
     def __init__(
-        self, patch_shape, sigma_bm4d=16, transform=None,
-        preserve_foreground=True, offsets=None,
+        self,
+        patch_shape,
+        sigma_bm4d=16,
+        transform=None,
+        preserve_foreground=True,
+        offsets=None,
     ):
         """
         Instantiates a ValidateDataset object.
@@ -1024,16 +1029,15 @@ class CachedPatchDataset(Dataset):
         Transform mapping counts to the normalized domain.
     """
 
-    def __init__(
-        self, cache_dir, transform=None, preserve_foreground=True,
-    ):
+    def __init__(self, cache_dir, transform=None, preserve_foreground=True):
         """
         Instantiates a CachedPatchDataset.
 
         Parameters
         ----------
-        cache_dir : str
-            Directory holding raw.npy, teacher.npy, and fg.npy.
+        cache_dir : str or Iterable[str]
+            Directory or list of directories containing raw.npy, teacher.npy,
+            and fg.npy.
         transform : IntensityTransform, optional
             Transform mapping counts to the normalized domain. Default is an
             asinh transform.
@@ -1047,8 +1051,12 @@ class CachedPatchDataset(Dataset):
         # Create cache directory list
         if isinstance(cache_dir, (str, os.PathLike)):
             cache_dirs = [cache_dir]
-        else:
+        elif isinstance(cache_dir, Iterable):
             cache_dirs = list(cache_dir)
+        else:
+            raise TypeError(
+                "cache_dir must be a path or an iterable of paths"
+            )
 
         # Load arrays with mmap mode
         self.raw = self._load_cached_arrs(cache_dirs, "raw")
@@ -1088,15 +1096,28 @@ class CachedPatchDataset(Dataset):
         )
 
     def _get_arrays(self, idx):
-        ds, local_idx = self._locate(idx)
-        raw = np.asarray(self.raw[ds][local_idx], dtype=np.float32)
-        teacher = np.asarray(self.teacher[ds][local_idx], dtype=np.float32)
-        fg_mask = np.asarray(self.fg[ds][local_idx], dtype=np.float32)
+        """
+        Retrieves raw cached arrays for a global sample index.
+    
+        Parameters
+        ----------
+        idx : int
+            Global sample index.
+
+        Returns
+        -------
+        Tuple[np.ndarray]
+            Raw counts, teacher target, and foreground mask arrays.
+        """
+        cache_idx, local = self._locate(idx)
+        raw = np.asarray(self.raw[cache_idx][local], dtype=np.float32)
+        teacher = np.asarray(self.teacher[cache_idx][local], dtype=np.float32)
+        fg_mask = np.asarray(self.fg[cache_idx][local], dtype=np.float32)
         return raw, teacher, fg_mask
 
     def _locate(self, idx):
         """
-        Maps a global dataset index to a cache index and local offset.
+        Maps a global sample index to a cache index and local offset.
 
         Parameters
         ----------
@@ -1105,8 +1126,8 @@ class CachedPatchDataset(Dataset):
 
         Returns
         -------
-        ds : int
-            Index of the dataset cache containing the sample.
+        cache_idx : int
+            Index of the cache containing the sample.
         offset : int
             Local index within the selected cache.
         """
@@ -1115,16 +1136,33 @@ class CachedPatchDataset(Dataset):
             raise IndexError(idx)
 
         # Find dataset and local indices
-        ds = np.searchsorted(self.cumulative_lengths, idx, side="right")
+        cache_idx = np.searchsorted(
+            self.cumulative_lengths, idx, side="right"
+        )
         offset = (
             idx
-            if ds == 0
-            else idx - self.cumulative_lengths[ds - 1]
+            if cache_idx == 0
+            else idx - self.cumulative_lengths[cache_idx - 1]
         )
-        return ds, offset
+        return cache_idx, offset
 
     @staticmethod
     def _load_cached_arrs(cache_dirs, name):
+        """
+        Loads memory-mapped arrays from multiple cache directories.
+
+        Parameters
+        ----------
+        cache_dirs : List[str]
+            Cache directories containing the array files.
+        name : str
+            Array name (e.g., "raw", "teacher", or "fg").
+
+        Returns
+        -------
+        List[np.ndarray]
+            Memory-mapped arrays, one per cache directory.
+        """
         return [
             np.load(os.path.join(d, f"{name}.npy"), mmap_mode="r")
             for d in cache_dirs

--- a/src/aind_exaspim_image_compression/machine_learning/data_handling.py
+++ b/src/aind_exaspim_image_compression/machine_learning/data_handling.py
@@ -77,6 +77,8 @@ def build_training_example(
         transform.forward(target),
         fg.astype(np.float32),
     )
+
+
 from aind_exaspim_image_compression.utils.swc_util import Reader
 
 
@@ -1039,19 +1041,32 @@ class CachedPatchDataset(Dataset):
             Whether the target keeps raw counts on the foreground. Default is
             True.
         """
-        super(CachedPatchDataset, self).__init__()
-        self.raw = np.load(os.path.join(cache_dir, "raw.npy"), mmap_mode="r")
-        self.teacher = np.load(
-            os.path.join(cache_dir, "teacher.npy"), mmap_mode="r"
-        )
-        self.fg = np.load(os.path.join(cache_dir, "fg.npy"), mmap_mode="r")
+        # Call parent class
+        super().__init__()
+
+        # Create cache directory list
+        if isinstance(cache_dir, (str, os.PathLike)):
+            cache_dirs = [cache_dir]
+        else:
+            cache_dirs = list(cache_dir)
+
+        # Load arrays with mmap mode
+        self.raw = self._load_cached_arrs(cache_dirs, "raw")
+        self.teacher = self._load_cached_arrs(cache_dirs, "teacher")
+        self.fg = self._load_cached_arrs(cache_dirs, "fg")
+        self._validate_cache()
+
+        self.lengths = [len(x) for x in self.raw]
+        self.cumulative_lengths = np.cumsum(self.lengths)
+
+        # Instance attributes
         self.transform = transform or build_transform({"kind": "asinh"})
         self.preserve_foreground = preserve_foreground
-        self.patch_shape = tuple(self.raw.shape[1:])
+        self.patch_shape = tuple(self.raw[0].shape[1:])
 
     def __len__(self):
         """Number of cached training examples."""
-        return len(self.raw)
+        return int(self.cumulative_lengths[-1])
 
     def __getitem__(self, idx):
         """
@@ -1067,64 +1082,79 @@ class CachedPatchDataset(Dataset):
         Tuple[numpy.ndarray]
             (x, y, fg_mask) for the model.
         """
-        raw = np.asarray(self.raw[idx], dtype=np.float32)
-        teacher = np.asarray(self.teacher[idx], dtype=np.float32)
-        fg_mask = np.asarray(self.fg[idx])
+        raw, teacher, fg_mask = self._get_arrays(idx)
         return build_training_example(
             self.transform, self.preserve_foreground, raw, teacher, fg_mask
         )
 
+    def _get_arrays(self, idx):
+        ds, local_idx = self._locate(idx)
+        raw = np.asarray(self.raw[ds][local_idx], dtype=np.float32)
+        teacher = np.asarray(self.teacher[ds][local_idx], dtype=np.float32)
+        fg_mask = np.asarray(self.fg[ds][local_idx], dtype=np.float32)
+        return raw, teacher, fg_mask
 
-class CachedValidateDataset(Dataset):
-    """
-    Validation dataset backed by a precomputed count-space patch cache.
-
-    Mirrors CachedPatchDataset but reproduces the ValidateDataset interface:
-    a fixed set of examples iterated in order (not sampled at random), whose
-    __getitem__ also returns the raw counts needed for the count-space
-    metrics. The expensive cloud reads + BM4D + foreground masks are
-    precomputed once (see scripts/precompute.py --split val); this dataset
-    applies only the cheap transform + target construction, so a cache-backed
-    training run needs no cloud access or BM4D at startup.
-
-    Attributes
-    ----------
-    patch_shape : Tuple[int]
-        Shape of the cached patches.
-    transform : IntensityTransform
-        Transform mapping counts to the normalized domain.
-    """
-
-    def __init__(
-        self, cache_dir, transform=None, preserve_foreground=True,
-    ):
+    def _locate(self, idx):
         """
-        Instantiates a CachedValidateDataset.
+        Maps a global dataset index to a cache index and local offset.
 
         Parameters
         ----------
-        cache_dir : str
-            Directory holding raw.npy, teacher.npy, and fg.npy.
-        transform : IntensityTransform, optional
-            Transform mapping counts to the normalized domain. Default is an
-            asinh transform.
-        preserve_foreground : bool, optional
-            Whether the target keeps raw counts on the foreground. Default is
-            True.
-        """
-        super(CachedValidateDataset, self).__init__()
-        self.raw = np.load(os.path.join(cache_dir, "raw.npy"), mmap_mode="r")
-        self.teacher = np.load(
-            os.path.join(cache_dir, "teacher.npy"), mmap_mode="r"
-        )
-        self.fg = np.load(os.path.join(cache_dir, "fg.npy"), mmap_mode="r")
-        self.transform = transform or build_transform({"kind": "asinh"})
-        self.preserve_foreground = preserve_foreground
-        self.patch_shape = tuple(self.raw.shape[1:])
+        idx : int
+            Global sample index.
 
-    def __len__(self):
-        """Number of cached validation examples."""
-        return len(self.raw)
+        Returns
+        -------
+        ds : int
+            Index of the dataset cache containing the sample.
+        offset : int
+            Local index within the selected cache.
+        """
+        # Check for valid index
+        if idx < 0 or idx >= len(self):
+            raise IndexError(idx)
+
+        # Find dataset and local indices
+        ds = np.searchsorted(self.cumulative_lengths, idx, side="right")
+        offset = (
+            idx
+            if ds == 0
+            else idx - self.cumulative_lengths[ds - 1]
+        )
+        return ds, offset
+
+    @staticmethod
+    def _load_cached_arrs(cache_dirs, name):
+        return [
+            np.load(os.path.join(d, f"{name}.npy"), mmap_mode="r")
+            for d in cache_dirs
+        ]
+
+    def _validate_cache(self):
+        # Check same number of cached datasets
+        assert len(self.raw) == len(self.teacher) == len(self.fg)
+
+        # Check cache is nonempty
+        if len(self.raw) == 0:
+            raise ValueError("No cached arrays found")
+
+        # Check patch shapes are the same within dataset
+        for raw, teacher, fg in zip(self.raw, self.teacher, self.fg):
+            assert len(raw) == len(teacher) == len(fg)
+            assert raw.shape[1:] == teacher.shape[1:] == fg.shape[1:]
+
+        # Check patch shapes are same across datasets
+        shapes = {r.shape[1:] for r in self.raw}
+        if len(shapes) > 1:
+            raise ValueError(
+                f"Inconsistent patch shapes across cache_dirs: {shapes}"
+            )
+
+
+class CachedValidateDataset(CachedPatchDataset):
+    """
+    Cached validation dataset with raw counts returned for metrics.
+    """
 
     def __getitem__(self, idx):
         """
@@ -1142,9 +1172,7 @@ class CachedValidateDataset(Dataset):
             input, target, raw counts (for count-space metrics), and the
             foreground mask (float 0/1).
         """
-        raw = np.asarray(self.raw[idx], dtype=np.float32)
-        teacher = np.asarray(self.teacher[idx], dtype=np.float32)
-        fg_mask = np.asarray(self.fg[idx])
+        raw, teacher, fg_mask = self._get_arrays(idx)
         x, y, fg = build_training_example(
             self.transform, self.preserve_foreground, raw, teacher, fg_mask
         )

--- a/tests/test_train_bm4dnet.py
+++ b/tests/test_train_bm4dnet.py
@@ -5,7 +5,6 @@ import runpy
 import tempfile
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
 
@@ -75,11 +74,12 @@ class CachedTrainingTest(unittest.TestCase):
                 load_transform(str(train_cache), str(val_cache))
 
     def test_cache_transforms_must_match(self):
-        """Train and validation caches cannot use different transforms."""
+        """Every train and validation cache must use the same transform."""
         load_transform = self.namespace["_load_cached_transform"]
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            train_cache = self._make_cache(root, "train")
+            train_cache = self._make_cache(root, "train-0")
+            extra_train_cache = self._make_cache(root, "train-1")
             val_cache = self._make_cache(
                 root,
                 "val",
@@ -89,7 +89,27 @@ class CachedTrainingTest(unittest.TestCase):
                 },
             )
             with self.assertRaisesRegex(ValueError, "different transforms"):
-                load_transform(str(train_cache), str(val_cache))
+                load_transform(
+                    [str(train_cache), str(extra_train_cache)],
+                    [str(val_cache)],
+                )
+
+    def test_each_cache_in_an_iterable_is_validated(self):
+        """Missing files in any iterable entry fail before construction."""
+        load_transform = self.namespace["_load_cached_transform"]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            train_cache = self._make_cache(root, "train-0")
+            incomplete = self._make_cache(
+                root, "train-1", omit=("teacher.npy",)
+            )
+            val_cache = self._make_cache(root, "val")
+            with self.assertRaisesRegex(
+                FileNotFoundError, r"train_cache_dir\[1\].*teacher.npy"
+            ):
+                load_transform(
+                    [str(train_cache), str(incomplete)], str(val_cache)
+                )
 
     def test_training_uses_only_cached_datasets(self):
         """Training constructs both cache adapters and records cache config."""
@@ -115,14 +135,15 @@ class CachedTrainingTest(unittest.TestCase):
         try:
             with tempfile.TemporaryDirectory() as directory:
                 root = Path(directory)
-                train_cache = self._make_cache(root, "train")
+                train_cache = self._make_cache(root, "train-0")
+                extra_train_cache = self._make_cache(root, "train-1")
                 val_cache = self._make_cache(root, "val")
                 transform = self.namespace["_load_cached_transform"](
-                    str(train_cache), str(val_cache)
+                    [str(train_cache), str(extra_train_cache)],
+                    str(val_cache),
                 )
-                train_dataset = SimpleNamespace(
-                    raw=[object(), object()], transform=transform
-                )
+                train_dataset = MagicMock(spec_set=["__len__"])
+                train_dataset.__len__.return_value = 2
                 val_dataset = MagicMock()
                 val_dataset.__len__.return_value = 3
                 val_dataset.transform = transform
@@ -143,11 +164,14 @@ class CachedTrainingTest(unittest.TestCase):
                 ) as init_datasets, patch.dict(
                     globals_, {"Trainer": trainer_factory}
                 ):
-                    train(str(train_cache), str(val_cache))
+                    train(
+                        [str(train_cache), str(extra_train_cache)],
+                        str(val_cache),
+                    )
 
                 init_datasets.assert_not_called()
                 cached_train.assert_called_once_with(
-                    str(train_cache),
+                    [str(train_cache), str(extra_train_cache)],
                     transform=ANY,
                     preserve_foreground=True,
                 )
@@ -158,7 +182,10 @@ class CachedTrainingTest(unittest.TestCase):
                 )
                 trainer.run.assert_called_once_with(train_dataset, val_dataset)
                 config = trainer.save_config.call_args.args[0]
-                self.assertEqual(config["train_cache_dir"], str(train_cache))
+                self.assertEqual(
+                    config["train_cache_dir"],
+                    [str(train_cache), str(extra_train_cache)],
+                )
                 self.assertEqual(config["val_cache_dir"], str(val_cache))
                 self.assertEqual(config["transform_cfg"], transform.cfg)
                 self.assertTrue(config["use_amp"])


### PR DESCRIPTION
### Motivation
We now have cached datasets generated from alpha, beta, beta2 whole-brain images and would like to train a model using some or possibly all of them.

### Summary

Refactored the cache-backed datasets to support loading multiple precomputed cache directories as a single dataset. Also reduced duplicated dataset logic between training and validation by refactoring validation to inherit from CachedPatchDataset.

### Changes

- Updated "CachedPatchDataset" to support a list of cache directories:
  - Multiple "raw.npy", "teacher.npy", and "fg.npy" cache shards can now be combined into one dataset.
  - Added global-to-local index mapping so DataLoader indexing remains unchanged while samples are loaded from the correct cache shard.
  - Preserved memory-mapped loading to avoid duplicating cached data in memory.

- Added shared cache loading and validation utilities:
  - Centralized cache loading through "_load_cached_arrs".
  - Added "_validate_cache" checks to ensure:
    - raw/teacher/foreground arrays have matching numbers of examples.
    - patch shapes are consistent within and across cache directories.

- Refactored "CachedValidateDataset" to inherit from "CachedPatchDataset":
  - Removed duplicate cache initialization and indexing logic.
  - Reuses the same cache access path while extending the output format to include raw counts required for validation metrics.
