### PR TITLE
Fix test failures

### DIFF
--- a/src/aind_exaspim_image_compression/machine_learning/train.py
+++ b/src/aind_exaspim_image_compression/machine_learning/train.py
@@ -99,8 +99,8 @@ class Trainer:
         self.prefetch = prefetch
         self.val_every = max(1, int(val_every))
         self.seed = seed
-        self.use_amp = bool(use_amp and device.startswith("cuda"))
-        self.use_amp_validation = bool(use_amp_validation and device.startswith("cuda"))
+        self.use_amp = bool(use_amp)
+        self.use_amp_validation = bool(use_amp_validation)
 
         self.codec = blosc.Blosc(cname="zstd", clevel=6, shuffle=blosc.SHUFFLE)
         self.criterion = SignalPreservingLoss(fg_weight=fg_weight)
@@ -113,7 +113,10 @@ class Trainer:
         # Scale the loss before backward so small float16 gradients do not
         # underflow (and are unscaled before the step). Disabled => no-op, so
         # the same code path is correct with and without AMP.
-        self.scaler = torch.amp.GradScaler("cuda", enabled=self.use_amp)
+        device_type = torch.device(self.device).type
+        self.scaler = torch.amp.GradScaler(
+            device_type, enabled=self.use_amp
+        )
 
     # --- Core Routines ---
     def run(self, train_dataset, val_dataset):

--- a/tests/test_full_cache_training.py
+++ b/tests/test_full_cache_training.py
@@ -155,14 +155,19 @@ class TrainerShuffleTest(unittest.TestCase):
             finally:
                 trainer.writer.close()
 
-    def test_trainer_sets_epoch_and_persists_seed(self):
-        """Trainer passes its seed, sets every epoch, and saves the seed."""
+    def test_trainer_uses_local_scheduler_and_persists_seed(self):
+        """Trainer configures its run-local scheduler and persists its seed."""
         model = torch.nn.Linear(1, 1)
         dataset = SimpleNamespace(
             patch_shape=(1, 1, 1), transform=IdentityTransform()
         )
         train_loader = MagicMock()
+        train_loader.__len__.return_value = 3
+        train_loader.__iter__.side_effect = lambda: iter(
+            [(None, None, None)] * 3
+        )
         val_loader = MagicMock()
+        scheduler = MagicMock()
 
         with tempfile.TemporaryDirectory() as directory:
             trainer = Trainer(
@@ -175,14 +180,16 @@ class TrainerShuffleTest(unittest.TestCase):
                 seed=42,
             )
             trainer.train_step = MagicMock(return_value=1.0)
-            trainer.validate_step = MagicMock(return_value=(1.0, 2.0, False))
-            trainer.scheduler.step = MagicMock()
             try:
                 with patch(
                     "aind_exaspim_image_compression.machine_learning."
                     "train.DataLoader",
                     side_effect=[train_loader, val_loader],
-                ) as loader_factory:
+                ) as loader_factory, patch(
+                    "aind_exaspim_image_compression.machine_learning."
+                    "train.CosineAnnealingLR",
+                    return_value=scheduler,
+                ) as scheduler_factory:
                     trainer.run(dataset, dataset)
 
                 self.assertEqual(
@@ -208,6 +215,11 @@ class TrainerShuffleTest(unittest.TestCase):
                 self.assertEqual(
                     train_loader.set_epoch.call_args_list, [call(0), call(1)]
                 )
+                scheduler_factory.assert_called_once_with(
+                    trainer.optimizer, T_max=6
+                )
+                self.assertEqual(scheduler.step.call_count, 6)
+                self.assertFalse(hasattr(trainer, "scheduler"))
 
                 trainer.save_config({})
                 with open(


### PR DESCRIPTION
## Summary

  Fix training test failures related to CPU AMP configuration and the refactored learning-rate scheduler.

## Changes

  - Preserve explicitly configured training and validation AMP settings on CPU and configure GradScaler using the trainer’s actual device type. Note that both of these have been supported on CPU since PyTorch 2.3+
  - Update the stale scheduler test to reflect that the scheduler is local to Trainer.run().
  - Verify the scheduler horizon uses the total optimizer-step count and advances once per batch.

## Testing

  - 66 passed
  - 1 subtest passed
  - 2 existing ome-zarr deprecation warnings remain.